### PR TITLE
Design, usability and performance improvements for AVL tree

### DIFF
--- a/Data/AVL/Dependent/Dict.idr
+++ b/Data/AVL/Dependent/Dict.idr
@@ -12,29 +12,23 @@ import Data.AVL.Dependent.Tree
 
 %default total
 
-data Dict' : (k : Type) -> Ord k -> Type -> Type where
-  MkDict : {k : Type}
-        -> {v : Type}
-        -> AVLTree h k o v
-        -> Dict' k o v
-
-Dict : (k : Type) -> {default %instance o : Ord k} -> (v : Type) -> Type
-Dict k {o = o} v = Dict' k o v
+data Dict : (k : Type) -> Type -> Type where
+  MkDict : AVLTree h k v -> Dict k v
 
 ||| Empty
-empty : (o : Ord k) => Dict k {o = o} v
+empty : (Ord k) => Dict k v
 empty = MkDict (Element Empty AVLEmpty)
 
-insert : (o : Ord k) => k -> v -> Dict k {o = o} v -> Dict k {o = o} v
+insert : (Ord k) => k -> v -> Dict k v -> Dict k v
 insert key val (MkDict d) = MkDict $ Sigma.getProof (runInsertRes $ Tree.insert key val d)
 
 ||| Update the value for the given key.
-update : (o : Ord k) => k -> (v -> v) -> Dict k {o = o} v -> Dict k {o = o} v
+update : (Ord k) => k -> (v -> v) -> Dict k v -> Dict k v
 update x ufunc (MkDict d) = MkDict $ Tree.update x ufunc d
 
 -- -------------------------------------------------------------------- [ List ]
 
-toList : Dict k {o = o} v -> List (k,v)
+toList : Dict k v -> List (k,v)
 toList (MkDict d) = Tree.toList d
 
 fromList : Ord k => List (k,v) -> Dict k v
@@ -43,36 +37,36 @@ fromList kvs = MkDict $ Sigma.getProof $ Tree.fromList kvs
 
 -- ----------------------------------------------------------------- [ Queries ]
 
-lookup : (o : Ord k) => k -> Dict k {o = o} v -> Maybe v
+lookup : (Ord k) => k -> Dict k v -> Maybe v
 lookup k (MkDict d) = Tree.lookup k d
 
-keys : Dict k {o = o} v -> List k
+keys : Dict k v -> List k
 keys (MkDict d) = Tree.keys d
 
-values : Dict k {o = o} v -> List v
+values : Dict k v -> List v
 values (MkDict d) = Tree.values d
 
-size : Dict k {o = o} v -> Nat
+size : Dict k v -> Nat
 size (MkDict d) = Tree.size d
 
-hasKey : k -> Dict k {o = o} v -> Bool
+hasKey : (Ord k) => k -> Dict k v -> Bool
 hasKey key (MkDict d) = Tree.hasKey key d
 
-hasValue : (Eq v) => v -> Dict k {o = o} v -> Bool
+hasValue : (Eq v) => v -> Dict k v -> Bool
 hasValue val (MkDict d) = Tree.hasValue val d
 
-findKey : (pred : v -> Bool) -> Dict k {o = o} v -> Maybe k
+findKey : (pred : v -> Bool) -> Dict k v -> Maybe k
 findKey pred (MkDict d) = Tree.findKey pred d
 
-findKeyOf : (Eq v) => v -> Dict k {o = o} v -> Maybe k
+findKeyOf : (Eq v) => v -> Dict k v -> Maybe k
 findKeyOf v (MkDict d) = Tree.findKeyOf v d
 
-instance (Eq k, Eq v) => Eq (Dict k {o = o} v) where
+instance (Eq k, Eq v) => Eq (Dict k v) where
    (==) (MkDict {h = h} x) (MkDict {h = h'} y) with (decEq h h')
      (==) (MkDict {h = h} x) (MkDict {h = h} y)  | Yes Refl = x == y
      (==) (MkDict {h = h} x) (MkDict {h = h'} y) | No _     = False
 
-instance (Show k, Show v) => Show (Dict k {o = o} v) where
+instance (Show k, Show v) => Show (Dict k v) where
   show (MkDict d) = show d
 
 -- --------------------------------------------------------------------- [ EOF ]

--- a/Data/AVL/Dependent/Graph.idr
+++ b/Data/AVL/Dependent/Graph.idr
@@ -32,6 +32,9 @@ AList b = List (NodeID, Maybe b)
 
 -- ------------------------------------------------------------------- [ Types ]
 
+GraphRep : (vTy : Type) -> (eTy : Type) -> Type
+GraphRep vTy eTy = Dict (NodeID) (vTy, AList eTy)
+
 ||| A compact adjacency list representation of a graph.
 |||
 ||| Implementation details:
@@ -64,10 +67,7 @@ record Graph (vTy : Type) (eTy : Type) where
   constructor MkGraph
   counter : NodeID
   legend  : List (vTy, NodeID)
-  graph   : Dict (NodeID) (vTy, AList eTy)
-
-GraphRep : (vTy : Type) -> (eTy : Type) -> Type
-GraphRep vTy eTy = Dict (NodeID) (vTy, AList eTy)
+  graph   : GraphRep vTy eTy
 
 Legend : Type -> Type
 Legend vTy = List (vTy, NodeID)
@@ -105,7 +105,6 @@ mkEmptyGraph = MkGraph Z Nil empty
 addNode : Eq v => v -> Graph v e -> Graph v e
 addNode val (MkGraph c l g) = MkGraph (S c) newL newG
   where
-    partial
     newG : GraphRep v e
     newG = insert c (val,Nil) g
 
@@ -129,7 +128,7 @@ addEdge (x,y,l) g =
       False => g
   where
     validEdge : NodeID -> NodeID -> Bool
-    validEdge x y = isKey x (graph g) && isKey y (graph g)
+    validEdge x y = hasKey x (graph g) && hasKey y (graph g)
 
     doUpdate : (NodeID, NodeID, Maybe e) -> GraphRep v e -> GraphRep v e
     doUpdate (x,y,l) gr = update x (\(val,as) => (val, (y,l)::as)) gr

--- a/Data/AVL/Dependent/Graph.idr
+++ b/Data/AVL/Dependent/Graph.idr
@@ -33,7 +33,7 @@ AList b = List (NodeID, Maybe b)
 -- ------------------------------------------------------------------- [ Types ]
 
 GraphRep : (vTy : Type) -> (eTy : Type) -> Type
-GraphRep vTy eTy = Dict (NodeID) (vTy, AList eTy)
+GraphRep vTy eTy = Dict NodeID (vTy, AList eTy)
 
 ||| A compact adjacency list representation of a graph.
 |||

--- a/Data/AVL/Dependent/Set.idr
+++ b/Data/AVL/Dependent/Set.idr
@@ -3,52 +3,49 @@ module Data.AVL.Dependent.Set
 
 import Data.AVL.Dependent.Tree
 
--- ||| Alias for make it easier to work with.
--- Set : Nat -> (k : Type) -> {default %instance o : Ord k} -> Type
--- Set n k {o = o} = Dict' n k o Unit
+data Set' : (a : Type) -> Ord a -> Type where
+  MkSet : {a : Type} -> AVLTree n a o Unit -> Set' a o
 
-data Set : Type -> Type where
-  MkSet : {a : Type} -> {default %instance o : Ord a} -> Tree n a o Unit -> Set a
+Set : (a : Type) -> {default %instance o : Ord a} -> Type
+Set a {o = o} = Set' a o
 
 ||| Return a empty set.
-empty : Ord a => Set a
-empty = MkSet Empty
+empty : (o : Ord a) => Set {o = o} a
+empty = MkSet (Element Empty AVLEmpty)
 
 ||| Insert an element into a set.
-insert : Ord a => a -> Set a -> Set a
-insert a (MkSet m) = case (Tree.insert a () m) of
-  Grew x => MkSet x
-  Same x => MkSet x
+insert : (o : Ord a) => a -> Set {o = o} a -> Set {o = o} a
+insert a (MkSet m) = MkSet (Sigma.getProof $ runInsertRes (Tree.insert a () m))
 
 ||| Does the set contain the given element.
-contains : Ord a => a -> Set a -> Bool
+contains : (o : Ord a) => a -> Set {o = o} a -> Bool
 contains a (MkSet m) = isJust (lookup a m)
 
 ||| Construct a set that contains all elements in both of the input sets.
-union : Ord a => Set a -> Set a -> Set a
-union (MkSet m1) (MkSet m2) = MkSet $ Sigma.getProof $ fromList $ toList m1 ++ toList m2
+union : (o : Ord a) => Set {o = o} a -> Set {o = o} a -> Set {o = o} a
+union (MkSet m1) (MkSet m2) = MkSet (Sigma.getProof $ Tree.foldr insertElement (_ ** m1) m2)
+  where insertElement : (o : Ord a) => a -> Unit -> (h : Nat ** AVLTree h a o Unit) -> (h' : Nat ** AVLTree h' a o Unit)
+        insertElement k v m' = runInsertRes (Tree.insert k v (Sigma.getProof m'))
+
 
 ||| Construct a set that contains the elements from the first input
 ||| set but not the second.
 |||
 ||| *Note* Not an efficient operation as we are constructing a new set
 ||| instead of modifying the right one.
-difference : Ord a => Set a -> Set a -> Set a
-difference s1 (MkSet m2) = foldl (\t, (e,_) => if contains e s1 then Set.insert e t else t)  empty $ Tree.toList m2
+difference : (o : Ord a) => Set {o = o} a -> Set {o = o} a -> Set {o = o} a
+difference s1 (MkSet m2) = Tree.foldr (\e,_,t => if contains e s1 then Set.insert e t else t) empty $ m2
 
 ||| Construct a set that contains common elements of the input sets.
-intersection : Ord a => Set a -> Set a -> Set a
+intersection : (o : Ord a) => Set {o = o} a -> Set {o = o} a -> Set {o = o} a
 intersection s1 s2 = difference s1 (difference s1 s2)
 
 ||| Construct a list using the given set.
-toList : Set a -> List a
+toList : Set {o = o} a -> List a
 toList (MkSet m) = map fst $ Tree.toList m
 
 ||| Construct a set from the given list.
-fromList : Ord a => List a -> Set a
+fromList : (o : Ord a) => List a -> Set {o = o} a
 fromList xs = (foldl (\t,k => Set.insert k t) empty xs)
-
-instance Foldable Set where
-  foldr f e xs = foldr f e (Set.toList xs)
 
 -- --------------------------------------------------------------------- [ EOF ]

--- a/Data/AVL/Dependent/Set.idr
+++ b/Data/AVL/Dependent/Set.idr
@@ -3,28 +3,25 @@ module Data.AVL.Dependent.Set
 
 import Data.AVL.Dependent.Tree
 
-data Set' : (a : Type) -> Ord a -> Type where
-  MkSet : {a : Type} -> AVLTree n a o Unit -> Set' a o
-
-Set : (a : Type) -> {default %instance o : Ord a} -> Type
-Set a {o = o} = Set' a o
+data Set : (a : Type) -> Type where
+  MkSet : {a : Type} -> AVLTree n a Unit -> Set a
 
 ||| Return a empty set.
-empty : (o : Ord a) => Set {o = o} a
+empty : (Ord a) => Set a
 empty = MkSet (Element Empty AVLEmpty)
 
 ||| Insert an element into a set.
-insert : (o : Ord a) => a -> Set {o = o} a -> Set {o = o} a
+insert : (Ord a) => a -> Set a -> Set a
 insert a (MkSet m) = MkSet (Sigma.getProof $ runInsertRes (Tree.insert a () m))
 
 ||| Does the set contain the given element.
-contains : (o : Ord a) => a -> Set {o = o} a -> Bool
+contains : (Ord a) => a -> Set a -> Bool
 contains a (MkSet m) = isJust (lookup a m)
 
 ||| Construct a set that contains all elements in both of the input sets.
-union : (o : Ord a) => Set {o = o} a -> Set {o = o} a -> Set {o = o} a
+union : (Ord a) => Set a -> Set a -> Set a
 union (MkSet m1) (MkSet m2) = MkSet (Sigma.getProof $ Tree.foldr insertElement (_ ** m1) m2)
-  where insertElement : (o : Ord a) => a -> Unit -> (h : Nat ** AVLTree h a o Unit) -> (h' : Nat ** AVLTree h' a o Unit)
+  where insertElement : (Ord a) => a -> Unit -> (h : Nat ** AVLTree h a Unit) -> (h' : Nat ** AVLTree h' a Unit)
         insertElement k v m' = runInsertRes (Tree.insert k v (Sigma.getProof m'))
 
 
@@ -33,19 +30,22 @@ union (MkSet m1) (MkSet m2) = MkSet (Sigma.getProof $ Tree.foldr insertElement (
 |||
 ||| *Note* Not an efficient operation as we are constructing a new set
 ||| instead of modifying the right one.
-difference : (o : Ord a) => Set {o = o} a -> Set {o = o} a -> Set {o = o} a
+difference : (Ord a) => Set a -> Set a -> Set a
 difference s1 (MkSet m2) = Tree.foldr (\e,_,t => if contains e s1 then Set.insert e t else t) empty $ m2
 
 ||| Construct a set that contains common elements of the input sets.
-intersection : (o : Ord a) => Set {o = o} a -> Set {o = o} a -> Set {o = o} a
+intersection : (Ord a) => Set a -> Set a -> Set a
 intersection s1 s2 = difference s1 (difference s1 s2)
 
 ||| Construct a list using the given set.
-toList : Set {o = o} a -> List a
+toList : Set a -> List a
 toList (MkSet m) = map fst $ Tree.toList m
 
 ||| Construct a set from the given list.
-fromList : (o : Ord a) => List a -> Set {o = o} a
+fromList : (Ord a) => List a -> Set a
 fromList xs = (foldl (\t,k => Set.insert k t) empty xs)
+
+instance Foldable Set where
+  foldr f i (MkSet m) = foldr (\x,_,p => f x p) i m
 
 -- --------------------------------------------------------------------- [ EOF ]

--- a/Data/AVL/Dependent/Tree.idr
+++ b/Data/AVL/Dependent/Tree.idr
@@ -28,202 +28,183 @@ height b = S (height' b)
     height' (RHeavy {n}) = S n
     height' {n} (Balanced {n}) = n
 
-data Tree : Nat -> (k : Type) -> Ord k -> Type -> Type where
-  Empty : Tree 0 k o v
+data Tree : (k : Type) -> Ord k -> Type -> Type where
+  Empty : Tree k o v
   Node : (key : k)
       -> (val : v)
-      -> (l : Tree n k o v)
-      -> (r : Tree m k o v)
-      -> (b : Balance n m)
-      -> Tree (height b) k o v
+      -> (l : Tree k o v)
+      -> (r : Tree k o v)
+      -> Tree k o v
 
 %name Tree t, tree
 
+data AVLInvariant : Nat -> (Tree k o v) -> Type where
+  AVLEmpty : AVLInvariant 0 Empty
+  AVLNode  : AVLInvariant n l -> AVLInvariant m r -> (b : Balance n m) -> AVLInvariant (height b) (Node k v l r)
+
+%name AVLInvariant inv
+
+AVLTree : (n : Nat) -> (k : Type) -> (o : Ord k) -> (v : Type) ->  Type
+AVLTree n k o v = Subset (Tree k o v) (AVLInvariant n)
+
 -- --------------------------------------------------------------- [ Rotations ]
 data InsertRes : Nat -> (k : Type) -> (o : Ord k) -> Type -> Type where
-  Same : Tree n k o v     -> InsertRes n k o v
-  Grew : Tree (S n) k o v -> InsertRes n k o v
+  Same : AVLTree n k o v     -> InsertRes n k o v
+  Grew : AVLTree (S n) k o v -> InsertRes n k o v
 
 %name InsertRes res, r
 
-rotLeft : k -> v -> Tree n k o v -> Tree (S (S n)) k o v -> InsertRes (S (S n)) k o v
+rotLeft : k -> v -> AVLTree n k o v -> AVLTree (S (S n)) k o v -> InsertRes (S (S n)) k o v
 -- Impossible because Empty has depth 0 and we know the depth is at least 2 from the type
-rotLeft key val l Empty                           impossible
+rotLeft key val l (Element Empty AVLEmpty) impossible
 
-rotLeft key val l (Node key' val' rl rr Balanced) =
-    Grew $ Node key' val' (Node key val l rl RHeavy)
-                          rr LHeavy
+rotLeft key val (Element l invl) (Element (Node key' val' rl rr) (AVLNode invrl invrr Balanced)) =
+    Grew $ Element (Node key' val' (Node key val l rl) rr)
+                        (AVLNode (AVLNode invl invrl RHeavy) invrr LHeavy)
 
-rotLeft key val l (Node key' val' (Node key'' val'' rll rlr LHeavy) rr LHeavy) =
-    Same $ Node key'' val'' (Node key val   l   rll Balanced) -- Needs checking
-                            (Node key' val' rlr rr  RHeavy) Balanced
+rotLeft key val (Element l invl) (Element (Node key' val' (Node key'' val'' rll rlr) rr) (AVLNode (AVLNode invrll invrlr LHeavy) invrr LHeavy)) =
+    Same $ Element (Node key'' val'' (Node key val l rll) (Node key' val' rlr rr)) -- Needs Checking
+                        (AVLNode (AVLNode invl invrll Balanced) (AVLNode invrlr invrr RHeavy) Balanced)
 
-rotLeft key val l (Node key' val' (Node key'' val'' rll rlr RHeavy) rr LHeavy) =
-    Same $ Node key'' val'' (Node key  val  l   rll LHeavy)
-                            (Node key' val' rlr rr  Balanced) Balanced
+rotLeft key val (Element l invl) (Element (Node key' val' (Node key'' val'' rll rlr) rr) (AVLNode (AVLNode invrll invrlr RHeavy) invrr LHeavy)) =
+    Same $ Element (Node key'' val'' (Node key val l rll) (Node key' val' rlr rr))
+                        (AVLNode (AVLNode invl invrll LHeavy) (AVLNode invrlr invrr Balanced) Balanced)
 
-rotLeft key val l (Node key' val' (Node key'' val'' rll rlr  Balanced) rr LHeavy) =
-    Same $ Node key'' val'' (Node key  val  l   rll Balanced)
-                            (Node key' val' rlr rr  Balanced) Balanced -- Needs Checking
+rotLeft key val (Element l invl) (Element (Node key' val' (Node key'' val'' rll rlr) rr) (AVLNode (AVLNode invrll invrlr Balanced) invrr LHeavy)) =
+    Same $ Element (Node key'' val'' (Node key val l rll) (Node key' val' rlr rr))
+                        (AVLNode (AVLNode invl invrll Balanced) (AVLNode invrlr invrr Balanced) Balanced) -- Needs Checking
 
-rotLeft key val l (Node key' val' rl rr RHeavy) =
-    Same $ Node key' val' (Node key val l rl Balanced)
-                          rr Balanced
+rotLeft key val (Element l invl) (Element (Node key' val' rl rr) (AVLNode invrl invrr RHeavy)) =
+    Same $ Element (Node key' val' (Node key val l rl) rr)
+                        (AVLNode (AVLNode invl invrl Balanced) invrr Balanced)
 
+rotRight : k -> v -> AVLTree (S (S n)) k o v -> AVLTree n k o v -> InsertRes (S (S n)) k o v
+rotRight key val (Element Empty AVLEmpty) r impossible
 
+rotRight key'' val'' (Element (Node key val ll (Node key' val' lrl lrr))
+             (AVLNode invll (AVLNode invlrl invlrr RHeavy) RHeavy)) (Element r invr) =
+  Same $ Element (Node key' val' (Node key val ll lrl) (Node key'' val'' lrr r))
+                 (AVLNode (AVLNode invll invlrl LHeavy) (AVLNode invlrr invr Balanced) Balanced)
 
-rotRight : k -> v -> Tree (S (S n)) k o v -> Tree n k o v -> InsertRes (S (S n)) k o v
-rotRight key val Empty r impossible
+rotRight key'' val'' (Element (Node key val ll (Node key' val' lrl lrr))
+             (AVLNode invll (AVLNode invlrl invlrr LHeavy) RHeavy)) (Element r invr) =
+  Same $ Element (Node key' val' (Node key val ll lrl) (Node key'' val'' lrr r))
+                 (AVLNode (AVLNode invll invlrl Balanced) (AVLNode invlrr invr RHeavy) Balanced)
 
-rotRight key'' val'' (Node key val ll (Node key' val' lrl lrr RHeavy) RHeavy) r =
-  Same $ Node key' val' (Node key   val   ll  lrl LHeavy)
-                        (Node key'' val'' lrr r   Balanced) Balanced
+rotRight key val (Element (Node key' val' ll lr) (AVLNode invll invlr Balanced)) (Element r invr) =
+  Grew $ Element (Node key' val' ll (Node key val lr r))
+                 (AVLNode invll (AVLNode invlr invr LHeavy) RHeavy)
 
-rotRight key'' val'' (Node key val ll (Node key' val' lrl lrr LHeavy) RHeavy) r =
-  Same $ Node key' val' (Node key   val   ll  lrl Balanced)
-                        (Node key'' val'' lrr r    RHeavy) Balanced
+rotRight key val (Element (Node key' val' ll lr) (AVLNode invll invlr LHeavy)) (Element r invr) =
+  Same $ Element (Node key' val' ll (Node key val lr r))
+                 (AVLNode invll (AVLNode invlr invr Balanced) Balanced)
 
-rotRight key val (Node key' val' ll lr Balanced) r =
-  Grew $ Node key' val' ll
-                        (Node key val lr r LHeavy) RHeavy
-
-rotRight key val (Node key' val' ll lr LHeavy) r =
-  Same $ Node key' val' ll
-                        (Node key val lr r Balanced) Balanced
-
-rotRight key val (Node key' val' ll (Node key'' val'' lrl lrr Balanced) RHeavy) r =
-  Same $ Node key'' val'' (Node key' val' ll  lrl Balanced)
-                          (Node key   val lrr r   Balanced) Balanced
+rotRight key val (Element (Node key' val' ll (Node key'' val'' lrl lrr))
+             (AVLNode invll (AVLNode invlrl invlrr Balanced) RHeavy)) (Element r invr) =
+  Same $ Element (Node key'' val'' (Node key' val' ll lrl) (Node key val lrr r))
+                 (AVLNode (AVLNode invll invlrl Balanced) (AVLNode invlrr invr Balanced) Balanced)
 
 -- --------------------------------------------------------------- [ Insertion ]
-insert : (o : Ord k) => k -> v -> (t : Tree n k o v) -> InsertRes n k o v
-insert newKey newVal Empty = Grew (Node newKey newVal Empty Empty Balanced)
-insert newKey newVal (Node key val l r b) with (compare newKey key)
-  insert newKey newVal (Node key val l r b) | EQ = Same (Node newKey newVal l r b)
+insert : (o : Ord k) => k -> v -> (t : AVLTree n k o v) -> InsertRes n k o v
+insert newKey newVal (Element Empty AVLEmpty) = Grew (Element (Node newKey newVal Empty Empty)
+                                                              (AVLNode AVLEmpty AVLEmpty Balanced))
+insert newKey newVal (Element (Node key val l r) (AVLNode invl invr b)) with (compare newKey key)
+  insert newKey newVal (Element (Node key val l r) (AVLNode invl invr b)) | EQ = Same (Element (Node newKey newVal l r) (AVLNode invl invr b))
 
-  insert newKey newVal (Node key val l r b) | LT with (insert newKey newVal l)
-    insert newKey newVal (Node key val l r b)        | LT | (Same l') = Same (Node key val l' r b)
-    insert newKey newVal (Node key val l r LHeavy)   | LT | (Grew l') = rotRight key val l' r
-    insert newKey newVal (Node key val l r Balanced) | LT | (Grew l') = Grew (Node key val l' r LHeavy)
-    insert newKey newVal (Node key val l r RHeavy)   | LT | (Grew l') = Same (Node key val l' r Balanced)
+  insert newKey newVal (Element (Node key val l r) (AVLNode invl invr b)) | LT with (assert_total $ insert newKey newVal (Element l invl))
+    -- Totality checker not clever enough to see that this is smaller
+    insert newKey newVal (Element (Node key val l r) (AVLNode invl invr b))        | LT | (Same (Element l' invl'))
+                                                                                          = Same $ Element (Node key val l' r) (AVLNode invl' invr b)
+    insert newKey newVal (Element (Node key val l r) (AVLNode invl invr LHeavy))   | LT | (Grew (Element l' invl'))
+                                                                                          = rotRight key val (Element l' invl') (Element r invr)
+    insert newKey newVal (Element (Node key val l r) (AVLNode invl invr Balanced)) | LT | (Grew (Element l' invl'))
+                                                                                          = Grew $ Element (Node key val l' r) (AVLNode invl' invr LHeavy)
+    insert newKey newVal (Element (Node key val l r) (AVLNode invl invr RHeavy))   | LT | (Grew (Element l' invl'))
+                                                                                          = Same $ Element (Node key val l' r) (AVLNode invl' invr Balanced)
 
-  insert newKey newVal (Node key val l r b) | GT with (insert newKey newVal r)
-    insert newKey newVal (Node key val l r b)        | GT | (Same r') = Same (Node key val l r' b)
-    insert newKey newVal (Node key val l r LHeavy)   | GT | (Grew r') = Same (Node key val l r' Balanced)
-    insert newKey newVal (Node key val l r Balanced) | GT | (Grew r') = Grew (Node key val l r' RHeavy)
-    insert newKey newVal (Node key val l r RHeavy)   | GT | (Grew r') = rotLeft key val l r'
+  insert newKey newVal (Element (Node key val l r) (AVLNode invl invr b)) | GT with (assert_total $ insert newKey newVal (Element r invr))
+  -- Totality checker not clever enough to see that this is smaller
+    insert newKey newVal (Element (Node key val l r) (AVLNode invl invr b))        | GT | (Same (Element r' invr'))
+                                                                                          = Same $ Element (Node key val l r') (AVLNode invl invr' b)
+    insert newKey newVal (Element (Node key val l r) (AVLNode invl invr LHeavy))   | GT | (Grew (Element r' invr'))
+                                                                                          = Same $ Element (Node key val l r') (AVLNode invl invr' Balanced)
+    insert newKey newVal (Element (Node key val l r) (AVLNode invl invr Balanced)) | GT | (Grew (Element r' invr'))
+                                                                                          = Grew $ Element (Node key val l r') (AVLNode invl invr' RHeavy)
+    insert newKey newVal (Element (Node key val l r) (AVLNode invl invr RHeavy))   | GT | (Grew (Element r' invr'))
+                                                                                          = rotLeft key val (Element l invl) (Element r' invr')
 
--- ------------------------------------------------------------------ [ Update ]
+lookup : (o : Ord k) => k -> AVLTree h k o v -> Maybe v
+lookup key (Element t _) = lookup' key t
+  where lookup' : (o : Ord k) => k -> Tree k o v -> Maybe v
+        lookup' key Empty = Nothing
+        lookup' key (Node key' value' l r) with (compare key key')
+          lookup' key (Node key' value' l r) | LT = lookup' key l
+          lookup' key (Node key' value' l r) | EQ = Just value'
+          lookup' key (Node key' value' l r) | GT = lookup' key r
 
-||| Update value in the dictionary in place selecting key using a
-||| custom comparison function.
-updateValueBy : (o : Ord k) => (k -> Ordering)
-                            -> (v -> v)
-                            -> Tree h k o v
-                            -> InsertRes h k o v
-updateValueBy cmp ufunc Empty = Same Empty
-updateValueBy cmp ufunc (Node key val l r b) with (cmp key)
-  updateValueBy cmp ufunc (Node key val l r b) | EQ = Same (Node key (ufunc val) l r b)
-
-  updateValueBy cmp ufunc (Node key val l r b) | LT with (updateValueBy cmp ufunc l)
-    updateValueBy cmp ufunc (Node key val l r b)        | LT | (Same l') = Same (Node key val l' r b)
-    updateValueBy cmp ufunc (Node key val l r LHeavy)   | LT | (Grew l') = rotRight key val l' r
-    updateValueBy cmp ufunc (Node key val l r Balanced) | LT | (Grew l') = Grew (Node key val l' r LHeavy)
-    updateValueBy cmp ufunc (Node key val l r RHeavy)   | LT | (Grew l') = Same (Node key val l' r Balanced)
-
-  updateValueBy cmp ufunc (Node key val l r b) | GT with (updateValueBy cmp ufunc r)
-    updateValueBy cmp ufunc (Node key val l r b)        | GT | (Same r') = Same (Node key val l r' b)
-    updateValueBy cmp ufunc (Node key val l r LHeavy)   | GT | (Grew r') = Same (Node key val l r' Balanced)
-    updateValueBy cmp ufunc (Node key val l r Balanced) | GT | (Grew r') = Grew (Node key val l r' RHeavy)
-    updateValueBy cmp ufunc (Node key val l r RHeavy)   | GT | (Grew r') = rotLeft key val l r'
-
-
-fromList : (o : Ord k) => List (k, v) -> (n : Nat ** Tree n k o v)
-fromList [] = (0 ** Empty)
+fromList : (o : Ord k) => List (k, v) -> (n : Nat ** AVLTree n k o v)
+fromList [] = (0 ** Element Empty AVLEmpty)
 fromList ((k, v) :: xs) with (insert k v (getProof (fromList xs)))
   fromList ((k, v) :: xs) | (Same x) = (_ ** x)
   fromList ((k, v) :: xs) | (Grew x) = (_ ** x)
 
-toList : Tree n k o v -> List (k, v)
-toList Empty = []
-toList (Node key val l r b) = toList l ++ [(key, val)] ++ toList r
+foldr : (step : k -> v -> p -> p) -> (init : p) -> AVLTree n k o v -> p
+foldr step init (Element t _) = foldr' step init t
+  where foldr' : (k -> v -> p -> p) -> p -> Tree k o v -> p
+        foldr' step' init' Empty = init'
+        foldr' step' init' (Node key val l r) = foldr' step' (step' key val (foldr' step' init' r)) l
 
+toList : AVLTree n k o v -> List (k, v)
+toList = foldr (\k,v,xs => (k, v) :: xs) []
 
-lookupUsing : Ord k => (k -> Ordering) -> Tree h k o v -> Maybe v
-lookupUsing _ Empty        	   = Nothing
-lookupUsing f (Node k v l r b) =
-  case f k of
-    LT => lookupUsing f l
-    GT => lookupUsing f r
-    EQ => Just v
+size : AVLTree h k o v -> Nat
+size = foldr (\_,_=> S) 0
 
-lookup : Ord k => k -> Tree h k o v -> Maybe v
-lookup k d = lookupUsing (compare k) d
+keys : AVLTree h k o v -> List k
+keys = map fst . toList
 
-keys : Ord k => Tree h k o v -> List k
-keys Empty = Nil
-keys (Node k _ l r b) = keys l ++ [k] ++ keys r
+values : AVLTree h k o v -> List v
+values = map snd . toList
 
-values : Ord k => Tree h k o v -> List v
-values Empty = Nil
-values (Node _ v l r b) = values l ++ [v] ++ values r
+all : (pred : k -> v -> Bool) ->  AVLTree h k o v -> Bool
+all pred = foldr (\k,v,pred' => pred' && pred k v) True
 
-length : Ord k => Tree h k o v -> Nat
-length Empty = Z
-length (Node _ _ l r b) = 1 + length l + length r
+any : (pred : k -> v -> Bool) ->  AVLTree h k o v -> Bool
+any pred = foldr (\k,v,pred' => pred' || pred k v) False
 
-hasKeyUsing : (Ord k) => (k -> Ordering) -> Tree h k o v -> Bool
-hasKeyUsing f Empty = False
-hasKeyUsing f (Node k v l r b) =
-  case f k of
-    EQ => True
-    LT => (hasKeyUsing f l)
-    GT => (hasKeyUsing f r)
+hasKey : (o : Ord k) => k -> AVLTree h k o v -> Bool
+hasKey key = any (\key',value' => key == key')
 
-hasKey : (Ord k) => k -> Tree h k o v -> Bool
-hasKey k d = hasKeyUsing (compare k) d
+hasValue : (Eq v) => v -> AVLTree h k o v -> Bool
+hasValue value = any (\key',value' => value == value')
 
-hasValueUsing : Ord k => (v -> Bool) -> Tree h k o v -> Bool
-hasValueUsing f Empty = False
-hasValueUsing f (Node k v l r b) =
-  f v || (hasValueUsing f l) || (hasValueUsing f r)
+findKey : (pred : v -> Bool) -> AVLTree h k o v -> Maybe k
+findKey pred = foldr (\k,v,p => if pred v then Just k else p) Nothing
 
-hasValue : (Ord k, Eq v) => v -> Tree h k o v -> Bool
-hasValue v d = hasValueUsing (\x => v == x) d
-
-getKeyUsing : Ord k => (v -> Bool) -> Tree h k o v -> Maybe k
-getKeyUsing f Empty = Nothing
-getKeyUsing f d     =
-    foldr (\acc,res => isRes f acc res) Nothing $ Tree.toList d
-  where
-    isRes : (v -> Bool) -> (k,v) -> Maybe k -> Maybe k
-    isRes f (k,v) r = case f v of
-                         True  => Just k
-                         False => r
-
-getKey : (Ord k, Eq v) => v -> Tree h k o v -> Maybe k
-getKey v d = getKeyUsing (\x => x==v) d
-
-isKey : Ord k => k -> Tree h k o v -> Bool
-isKey k d = isJust $ lookup k d
+findKeyOf : (Eq v) => v -> AVLTree h k o v -> Maybe k
+findKeyOf value = findKey (== value)
 
 -- ----------------------------------------------------------------- [ Classes ]
+eqTree : (Eq k, Eq v) => Tree k o v -> Tree k o v -> Bool
+eqTree Empty              Empty              = True
+eqTree (Node xk xv xl xr) (Node yk yv yl yr) =
+  xk == yk  &&
+  xv == yv  &&
+  eqTree xl yl &&
+  eqTree xr yr
+eqTree _ _                                   = False
 
-eqTree : (Eq k, Eq v) => Tree h k o v -> Tree h' k p v -> Bool
-eqTree (Empty)               (Empty)               = True
-eqTree (Node xk xv xl xr _) (Node yk yv yl yr _) =
-    xk == yk  &&
-    xv == yv  &&
-    eqTree xl yl &&
-    eqTree xr yr -- Maybe add eq for balance...
-eqTree _ _ = False
-
-instance (Eq k, Eq v) => Eq (Tree h k o v) where
+instance (Eq k, Eq v) => Eq (Tree k o v) where
   (==) x y = eqTree x y
 
+instance (Eq k, Eq v) => Eq (AVLTree h k o v) where
+  (==) (Element t _) (Element t' _) = t == t'
 
-instance (Show k, Show v) => Show (Tree h k o v) where
+instance (Show k, Show v) => Show (Tree k o v) where
   show Empty              = ""
-  show (Node k v l r d) = unwords ["{", show l, "(", show k, ":", show v, "),", show r, "}"]
+  show (Node k v l r)     = unwords ["{", show l, "(", show k, ":", show v, "),", show r, "}"]
+
+instance (Show k, Show v) => Show (AVLTree h k o v) where
+  show (Element t _) = show t
 
 -- --------------------------------------------------------------------- [ EOF ]


### PR DESCRIPTION
I have tried to adjust some things in the AVL tree implementation in order to make the design more coherent, and improve performance.

I have made the following changes:
- Separation of invariant from data structure, in order to get full erasure of invariant at runtime (to save performance from having unary nats stored everywhere).
- Removed Using variants (since they would have not been corrected if not used with the correct Ord instance anyway) and changed the Graph to not use them
- Removed the parameterisation over Ord, it seems that it had introduced unification issues when being used, and I thought we should only roll it back when it becomes easier to use (i.e., when equality over type class instances is easier to get).
