### PR TITLE
Fixed layout of Contributors file

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,5 +1,7 @@
-= Contributors
+# Contributors
 
 Jan de Muijnck-Hughes, primary author
-Ahmad Salim -- Bug fixes
-David Christiansen -- silent provision of Dependently Typed AVL 
+
+Ahmad Salim, bug fixes
+
+David Christiansen, silent provision of Dependently Typed AVL 


### PR DESCRIPTION
It was made as a Markdown file, and so was rendered incorrectly; so I just fixed the layout so it looked nice.
