### PR TITLE
Update Data.RedBlack.Tree to use key-value pairs

### DIFF
--- a/Data/RedBlack/BTree.idr
+++ b/Data/RedBlack/BTree.idr
@@ -1,0 +1,63 @@
+-- --------------------------------------------------------------- [ BTree.idr ]
+-- Module    : BTree.idr
+-- Copyright : (c) 2017 See CONTRIBUTORS.md
+-- License   : see LICENSE
+-- --------------------------------------------------------------------- [ EOH ]
+||| Implementation of a Binary Tree as a Red-Black Binary Search Tree.
+|||
+||| The underlying Red-Black Tree is a Key-Value Tree, this library
+||| just wraps this up as a simple Binary tree for values i.e. keys.
+module Data.RedBlack.BTree
+
+import Data.RedBlack.Tree
+
+%default total
+%access export
+
+-- ------------------------------------------------------------- [ Definitions ]
+
+||| A Binary Search Tree.
+|||
+||| @ty The type of the elements in the tree.
+data BTree : (ty : Type) -> Type
+    where
+      MkTree : {a : Type} -> Tree a Unit -> BTree a
+
+-- --------------------------------------------------------------------- [ API ]
+
+||| Return an empty BTree.
+empty : Ord a => BTree a
+empty = MkTree empty
+
+||| Insert an element into the Tree.
+insert : (Ord a) => a -> BTree a -> BTree a
+insert a (MkTree t) = MkTree (Tree.insert a () t)
+
+||| Does the tree contain the given element?
+contains : (Ord a) => a -> BTree a -> Bool
+contains a (MkTree t) = isJust (Tree.lookup a t)
+
+||| How many nodes are in the tree?
+size : BTree a -> Nat
+size (MkTree t) = Tree.size t
+
+||| Construct an ordered list containing the elements of the tree.
+toList : BTree a -> List a
+toList (MkTree t) = map fst $ Tree.toList t
+
+||| Construct a tree from a list of elements.
+fromList : (Ord a) => List a -> BTree a
+fromList xs = (foldl (\t,k => BTree.insert k t) empty xs)
+
+-- --------------------------------------------------------------- [ Instances ]
+
+Foldable BTree where
+  foldr f i (MkTree t) = foldr (\x,_,p => f x p) i t
+
+-- Eq a => Eq (BTree a) where
+--   (==) (MkTree t) (MkTree t') = t == t'
+
+Show a => Show (BTree a) where
+  show s = "{ " ++ (unwords . intersperse "," . map show . BTree.toList $ s) ++ " }"
+
+-- --------------------------------------------------------------------- [ EOF ]

--- a/Data/Test/RedBlack.idr
+++ b/Data/Test/RedBlack.idr
@@ -9,7 +9,7 @@ module Data.Test.RedBlack
 import Test.Generic
 import Test.Random
 
-import Data.RedBlack.Tree
+import Data.RedBlack.BTree
 
 %access export
 
@@ -24,7 +24,7 @@ partial
 testBuilding : IO Bool
 testBuilding = genericTest
     (Just "List, Building" )
-    (Tree.size $ Tree.fromList (list1 ++ list1))
+    (BTree.size $ BTree.fromList (list1 ++ list1))
     30
     (==)
 
@@ -34,7 +34,7 @@ partial
 testUpdate : IO Bool
 testUpdate = genericTest
     (Just "Insert")
-    (Tree.size $ insert 1 $ Tree.fromList list2)
+    (BTree.size $ insert 1 $ BTree.fromList list2)
     31
     (==)
 
@@ -42,14 +42,14 @@ partial
 testContains : IO Bool
 testContains = genericTest
     (Just "Contains")
-    (Tree.contains 4 $ Tree.fromList [1,2,3,4])
+    (BTree.contains 4 $ BTree.fromList [1,2,3,4])
     (True)
     (==)
 
 partial
 runTest : IO ()
 runTest = do
-    putStrLn "Testing RedBlack Tree"
+    putStrLn "Testing RedBlack BTree"
     putStrLn infoLine
     NonReporting.runTests [
         testBuilding


### PR DESCRIPTION
Update Data.RedBlack.Tree to use key-value pairs.  Also adds a new
Data.RedBlack.BTree module for trees with values of type Unit, to be
used in place of the old Tree type.  Updates RedBlack tests to use the
new BTree type.